### PR TITLE
We're following more like GitHub Flow than GitFlow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Please note the following guidelines before submitting pull requests:
 
 - Use the [PSR-2 coding style](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
 - All new features must be covered by unit tests
-- Always create pull requests to the *develop* branch
+- Always create pull requests to the *master* branch


### PR DESCRIPTION
Re: https://github.com/digiaonline/lumen-graphql/pull/9#issuecomment-359450456:

> About the develop branch:
>
> This project's [CONTRIBUTING file](https://github.com/digiaonline/lumen-graphql/blob/master/.github/CONTRIBUTING.md) says "Always create pull requests to the *develop* branch", but [last March](https://nordsoftware.slack.com/archives/C0DH80HNZ/p1488379290000374) we decided to follow something closer to [GitHub Flow](https://guides.github.com/introduction/flow/) for new projects (discussion begins around [here](https://nordsoftware.slack.com/archives/C0DH80HNZ/p1488374782000314)). 
>
> So I'll delete this develop branch and update CONTRIBUTING.