### PR TITLE
Rename FooAbstract to AbstractFoo [#17]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,14 @@
         "youshido/graphql": "^1.5"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.9",
         "laravel/lumen-framework": "^5.5",
+        "mockery/mockery": "^0.9.9",
+        "nordsoftware/lumen-newrelic": "^1.1",
         "phpunit/phpunit": "^5.7",
         "vlucas/phpdotenv": "~2.2"
     },
     "suggest": {
-        "nordsoftware/lumen-newrelic": "^1.1"
+        "nordsoftware/lumen-newrelic": "New Relic instrumentation for the Lumen framework"
     },
     "license": "MIT",
     "authors": [

--- a/src/Fields/AbstractCreateEntityField.php
+++ b/src/Fields/AbstractCreateEntityField.php
@@ -9,9 +9,12 @@ use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Field\AbstractField;
 use Youshido\GraphQL\Type\InputObject\AbstractInputObjectType;
 use Youshido\GraphQL\Type\NonNullType;
-use Youshido\GraphQL\Type\Scalar\IdType;
 
-abstract class UpdateEntityFieldAbstract extends AbstractField
+/**
+ * Class AbstractCreateEntityField
+ * @package Digia\Lumen\GraphQL\Fields
+ */
+abstract class AbstractCreateEntityField extends AbstractField
 {
 
     use ResolvesNodesTrait;
@@ -30,14 +33,14 @@ abstract class UpdateEntityFieldAbstract extends AbstractField
      * @param ResolveContext $context
      * @return mixed
      */
-    abstract protected function updateEntity(ResolveContext $context);
+    abstract protected function createEntity(ResolveContext $context);
 
     /**
      * @inheritdoc
      */
     public function getDescription()
     {
-        return 'Updates an existing entity.';
+        return 'Creates a new entity.';
     }
 
     /**
@@ -45,19 +48,17 @@ abstract class UpdateEntityFieldAbstract extends AbstractField
      */
     public function build(FieldConfig $config)
     {
-        $config->addArgument('id', new NonNullType(new IdType()));
         $config->addArgument($this->getEntityKey(), new NonNullType($this->getInputType()));
     }
 
     /**
      * @inheritdoc
-     * @suppress PhanTypeMismatchArgument
      */
     public function resolve($value, array $args, ResolveInfo $info)
     {
         $context = new ResolveContext($value, $args, $info);
 
-        return $this->updateEntity($context);
+        return $this->createEntity($context);
     }
 
     /**
@@ -66,5 +67,14 @@ abstract class UpdateEntityFieldAbstract extends AbstractField
     protected function getEntityKey()
     {
         return camel_case($this->getEntityTypeName());
+    }
+
+    /**
+     * @param ResolveContext $context
+     * @return array
+     */
+    protected function getEntityProperties(ResolveContext $context)
+    {
+        return $context->getArgument($this->getEntityKey());
     }
 }

--- a/src/Fields/AbstractDeleteEntityField.php
+++ b/src/Fields/AbstractDeleteEntityField.php
@@ -11,7 +11,11 @@ use Youshido\GraphQL\Type\NonNullType;
 use Youshido\GraphQL\Type\Scalar\BooleanType;
 use Youshido\GraphQL\Type\Scalar\IdType;
 
-abstract class DeleteEntityFieldAbstract extends AbstractField
+/**
+ * Class AbstractDeleteEntityField
+ * @package Digia\Lumen\GraphQL\Fields
+ */
+abstract class AbstractDeleteEntityField extends AbstractField
 {
 
     use ResolvesNodesTrait;

--- a/src/Fields/AbstractEntityConnectionField.php
+++ b/src/Fields/AbstractEntityConnectionField.php
@@ -11,7 +11,11 @@ use Youshido\GraphQL\Relay\Connection\ArrayConnection;
 use Youshido\GraphQL\Relay\Connection\Connection;
 use Youshido\GraphQL\Type\AbstractType;
 
-abstract class EntityConnectionFieldAbstract extends AbstractField
+/**
+ * Class AbstractEntityConnectionField
+ * @package Digia\Lumen\GraphQL\Fields
+ */
+abstract class AbstractEntityConnectionField extends AbstractField
 {
 
     /**

--- a/src/Fields/AbstractEntityField.php
+++ b/src/Fields/AbstractEntityField.php
@@ -6,7 +6,11 @@ use Digia\Lumen\GraphQL\Models\ResolveContext;
 use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Field\AbstractField;
 
-abstract class EntityFieldAbstract extends AbstractField
+/**
+ * Class AbstractEntityField
+ * @package Digia\Lumen\GraphQL\Fields
+ */
+abstract class AbstractEntityField extends AbstractField
 {
 
     /**

--- a/src/Fields/AbstractNodeField.php
+++ b/src/Fields/AbstractNodeField.php
@@ -6,7 +6,7 @@ use Youshido\GraphQL\Config\Field\FieldConfig;
 use Youshido\GraphQL\Type\NonNullType;
 use Youshido\GraphQL\Type\Scalar\IdType;
 
-abstract class NodeFieldAbstractAbstract extends EntityFieldAbstract
+abstract class AbstractNodeField extends AbstractEntityField
 {
 
     /**

--- a/src/Fields/AbstractUpdateEntityField.php
+++ b/src/Fields/AbstractUpdateEntityField.php
@@ -9,8 +9,13 @@ use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Field\AbstractField;
 use Youshido\GraphQL\Type\InputObject\AbstractInputObjectType;
 use Youshido\GraphQL\Type\NonNullType;
+use Youshido\GraphQL\Type\Scalar\IdType;
 
-abstract class CreateEntityFieldAbstract extends AbstractField
+/**
+ * Class AbstractUpdateEntityField
+ * @package Digia\Lumen\GraphQL\Fields
+ */
+abstract class AbstractUpdateEntityField extends AbstractField
 {
 
     use ResolvesNodesTrait;
@@ -29,14 +34,14 @@ abstract class CreateEntityFieldAbstract extends AbstractField
      * @param ResolveContext $context
      * @return mixed
      */
-    abstract protected function createEntity(ResolveContext $context);
+    abstract protected function updateEntity(ResolveContext $context);
 
     /**
      * @inheritdoc
      */
     public function getDescription()
     {
-        return 'Creates a new entity.';
+        return 'Updates an existing entity.';
     }
 
     /**
@@ -44,17 +49,19 @@ abstract class CreateEntityFieldAbstract extends AbstractField
      */
     public function build(FieldConfig $config)
     {
+        $config->addArgument('id', new NonNullType(new IdType()));
         $config->addArgument($this->getEntityKey(), new NonNullType($this->getInputType()));
     }
 
     /**
      * @inheritdoc
+     * @suppress PhanTypeMismatchArgument
      */
     public function resolve($value, array $args, ResolveInfo $info)
     {
         $context = new ResolveContext($value, $args, $info);
 
-        return $this->createEntity($context);
+        return $this->updateEntity($context);
     }
 
     /**
@@ -63,14 +70,5 @@ abstract class CreateEntityFieldAbstract extends AbstractField
     protected function getEntityKey()
     {
         return camel_case($this->getEntityTypeName());
-    }
-
-    /**
-     * @param ResolveContext $context
-     * @return array
-     */
-    protected function getEntityProperties(ResolveContext $context)
-    {
-        return $context->getArgument($this->getEntityKey());
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
* Rename FooAbstract to AbstractFoo
* I'm not sure why we have `NodeFieldAbstractAbstract` in the first place.
@Jalle19  Could you please suggest some ideas how to write unit tests for those fields?
