### PR TITLE
Fix cannot generate schema.lock file

### DIFF
--- a/src/Commands/UpdateSchemaLockCommand.php
+++ b/src/Commands/UpdateSchemaLockCommand.php
@@ -64,7 +64,7 @@ class UpdateSchemaLockCommand extends Command implements CommandInterface
      */
     public function handle()
     {
-        $response = $this->graphQlService->getQueryResponse($this->getQueryPath());
+        $response = $this->graphQlService->getQueryResponse(file_get_contents($this->getQueryPath()));
 
         file_put_contents(LockFile::getAbsolutePath(), JsonEncoder::encode($response));
     }

--- a/tests/Commands/UpdateSchemaLockCommandTest.php
+++ b/tests/Commands/UpdateSchemaLockCommandTest.php
@@ -25,7 +25,7 @@ class UpdateSchemaLockCommandTest extends TestCase
 
         $service->expects($this->once())
                 ->method('getQueryResponse')
-                ->with(UpdateSchemaLockCommand::INTROSPECTION_GRAPHQL, []);
+                ->with(file_get_contents(UpdateSchemaLockCommand::INTROSPECTION_GRAPHQL), []);
 
         $command = new UpdateSchemaLockCommand($service);
         $command->handle();


### PR DESCRIPTION
Fix cannot generate schema.lock file. `getQueryResponse` needs a query string instead of a path.