### PR TITLE
Ensure always return query as string

### DIFF
--- a/src/Models/GraphQLError.php
+++ b/src/Models/GraphQLError.php
@@ -47,7 +47,7 @@ class GraphQLError
      */
     public function getQuery(): string
     {
-        return $this->query;
+        return json_encode($this->query);
     }
 
     /**


### PR DESCRIPTION
- Prevent the situation that NewRelicMiddleware cannot report the error to NewRelic because query is an array